### PR TITLE
Update Python versions in compatibility section.

### DIFF
--- a/content/pages/1.install.rst
+++ b/content/pages/1.install.rst
@@ -6,7 +6,7 @@ Install
 Compatibility:
 ==============
 
-Tested on OS X and Linux. Runs on Python 2.7 and 3.3+.
+Tested on macOS and Linux. Runs on Python 2.7 and 3.3+.
 
 I have not personally tested this on Windows, but all the underlying libraries
 used by this project are cross-platform compatible including Windows. If you

--- a/content/pages/1.install.rst
+++ b/content/pages/1.install.rst
@@ -6,7 +6,7 @@ Install
 Compatibility:
 ==============
 
-Tested on OS X and Linux. Runs on Python 2.6, 2.7, 3.3 and 3.4.
+Tested on OS X and Linux. Runs on Python 2.7 and 3.3+.
 
 I have not personally tested this on Windows, but all the underlying libraries
 used by this project are cross-platform compatible including Windows. If you


### PR DESCRIPTION
Remove 2.6 and uses `3.3+` wording.