### PR TITLE
Add info about the LESS default behavior to pager.md

### DIFF
--- a/content/pages/pager.md
+++ b/content/pages/pager.md
@@ -41,3 +41,6 @@ export LESS="-XFR"
 # Some pgcli users like to disable line wrapping.
 export LESS="-SRXF"
 ```
+
+If the `LESS` environment variable is not set, and `less` is the pager, then
+the `LESS` environment variable will automatically be set to `-SRXF`.


### PR DESCRIPTION
It was not immediately intuitive to me that pgcli would automatically set my `LESS` variable if it was not set. It seems good to document this behavior.