### PR TITLE
[typo] Fix "users_by_age" named query example

### DIFF
--- a/content/pages/named_queries.md
+++ b/content/pages/named_queries.md
@@ -94,7 +94,7 @@ each aggregated value.
 
 ### Raw Aggregation
 ```
-\ns users_by_age select * from users where id in ($*)
+\ns users_by_age select * from users where age in ($*)
 ```
 
 When you call a named query with parameters, just add any (at least one)


### PR DESCRIPTION
Considering the name of the query, we probably want to filter on the `age` column, not `id`.

---

Page: https://www.pgcli.com/named_queries.md ("Raw Aggregation" section).