### PR TITLE
brew tap no longer needed

### DIFF
--- a/content/pages/0.index.rst
+++ b/content/pages/0.index.rst
@@ -54,7 +54,6 @@ install postgresql if you don't already have it.
 
 .. code:: bash
 
-   $ brew tap dbcli/tap
    $ brew install pgcli
 
 If you're having trouble with the quick start, check the install_ page for


### PR DESCRIPTION
`brew tap` is no longer needed to install pgcli.