### PR TITLE
Fix link to "cmder" website in FAQ

### DIFF
--- a/content/pages/3.faq.rst
+++ b/content/pages/3.faq.rst
@@ -108,5 +108,5 @@ knows the answers for them.
 .. _`Python-Prompt-Toolkit`: https://github.com/jonathanslenders/python-prompt-toolkit 
 .. _Sqlparse: https://pypi.python.org/pypi/sqlparse
 .. _contact: {filename}/pages/6.about.rst
-.. _cmder: http://cmder.net/
+.. _cmder: http://cmder.app/
 .. _http://mycli.net: http://mycli.net


### PR DESCRIPTION
The typo was reported by @bendy05 at dbcli/pgcli#1490.