### PR TITLE
Add alternate text on images

### DIFF
--- a/content/pages/0.index.rst
+++ b/content/pages/0.index.rst
@@ -37,7 +37,7 @@ highlighting.
 * Source: https://github.com/dbcli/pgcli
 
 .. image:: {filename}/images/image01.png
-   :alt: Screenshot
+   :alt: Screenshot of pgcli showing SQL output and auto-completion on table names
    :width: 750px
 
 Quick Start

--- a/content/pages/completion.md
+++ b/content/pages/completion.md
@@ -14,28 +14,33 @@ Here are a few examples of smart completion.
 
 Only table names from the current database are suggested after the FROM keyword.
 
-<img src="images/docs/table.png" width=750 align="center">
+<img src="images/docs/table.png" width=750 align="center"
+     alt="Screenshot of pgcli auto-completion on table names in 'select * from ‸'">
 
 ### Column
 
 Column names from the current table are suggested after the WHERE clause.
 
-<img src="images/docs/column.png" width=750 align="center">
+<img src="images/docs/column.png" width=750 align="center"
+     alt="Screenshot of pgcli auto-completion on column names in 'select * from django_site where ‸'">
 
-### Insert 
+### Insert
 
 Insert statement will suggest the column names.
 
-<img src="images/docs/insert.png" width=750 align="center">
+<img src="images/docs/insert.png" width=750 align="center"
+     alt="Screenshot of pgcli auto-completion in 'insert into django_site values (‸'">
 
 ### Alias
 
 Aliases in the query are resolved and the columns from the table aliases are suggested.
 
-<img src="images/docs/alias.png" width=750 align="center">
+<img src="images/docs/alias.png" width=750 align="center"
+     alt="Screenshot of pgcli auto-completion on aliases tables in 'select * from django_site d join auth_group a on d.‸'">
 
 ## Fuzzy Match
 
 The completions are matched using a [fuzzy algorithm](http://blog.amjith.com/fuzzyfinder-in-10-lines-of-python). For example typing 'djmi' will match the table 'django_migrations' because 'djmi' has parts of matching substrings. Here's an example:
 
-<img src="images/docs/fuzzy.png" width=750 align="center">
+<img src="images/docs/fuzzy.png" width=750 align="center"
+     alt="Screenshot of pgcli auto-completion with fuzzy matching in 'select * from aup‸' that proposes 'auth_permission', 'auth_group', etc.">

--- a/content/pages/syntax.md
+++ b/content/pages/syntax.md
@@ -9,159 +9,159 @@ Here is a gallery of syntax color themes. These themes can be modified via the
 
 <figure>
 Click the image to toggle dark/light background.
-<img src='/images/syntax/dark/default.png' width=750 align=center data-alt='/images/syntax/light/default.png'>
+<img src='/images/syntax/dark/default.png' width=750 align=center data-alt='/images/syntax/light/default.png' alt="screenshot of pgcli with the default color theme">
 </figure>
 
 # manni
 
 <figure>
 Click the image to toggle dark/light background.
-<img src='/images/syntax/dark/manni.png' width=750 align=center data-alt='/images/syntax/light/manni.png'>
+<img src='/images/syntax/dark/manni.png' width=750 align=center data-alt='/images/syntax/light/manni.png' alt="screenshot of pgcli with the 'manni' color theme">
 </figure>
 
 # igor
 
 <figure>
 Click the image to toggle dark/light background.
-<img src='/images/syntax/dark/igor.png' width=750 align=center data-alt='/images/syntax/light/igor.png'>
+<img src='/images/syntax/dark/igor.png' width=750 align=center data-alt='/images/syntax/light/igor.png' alt="screenshot of pgcli with the 'igor' color theme">
 </figure>
 
 # xcode
 
 <figure>
 Click the image to toggle dark/light background.
-<img src='/images/syntax/dark/xcode.png' width=750 align=center data-alt='/images/syntax/light/xcode.png'>
+<img src='/images/syntax/dark/xcode.png' width=750 align=center data-alt='/images/syntax/light/xcode.png' alt="screenshot of pgcli with the 'xcode' color theme">
 </figure>
 
 # vim
 
 <figure>
 Click the image to toggle dark/light background.
-<img src='/images/syntax/dark/vim.png' width=750 align=center data-alt='/images/syntax/light/vim.png'>
+<img src='/images/syntax/dark/vim.png' width=750 align=center data-alt='/images/syntax/light/vim.png' alt="screenshot of pgcli with the 'vim' color theme">
 </figure>
 
 # autumn
 
 <figure>
 Click the image to toggle dark/light background.
-<img src='/images/syntax/dark/autumn.png' width=750 align=center data-alt='/images/syntax/light/autumn.png'>
+<img src='/images/syntax/dark/autumn.png' width=750 align=center data-alt='/images/syntax/light/autumn.png' alt="screenshot of pgcli with the 'autumn' color theme">
 </figure>
 
 # vs
 
 <figure>
 Click the image to toggle dark/light background.
-<img src='/images/syntax/dark/vs.png' width=750 align=center data-alt='/images/syntax/light/vs.png'>
+<img src='/images/syntax/dark/vs.png' width=750 align=center data-alt='/images/syntax/light/vs.png' alt="screenshot of pgcli with the 'vs' color theme">
 </figure>
 
 # rrt
 
 <figure>
 Click the image to toggle dark/light background.
-<img src='/images/syntax/dark/rrt.png' width=750 align=center data-alt='/images/syntax/light/rrt.png'>
+<img src='/images/syntax/dark/rrt.png' width=750 align=center data-alt='/images/syntax/light/rrt.png' alt="screenshot of pgcli with the 'rrt' color theme">
 </figure>
 
 # native
 
 <figure>
 Click the image to toggle dark/light background.
-<img src='/images/syntax/dark/native.png' width=750 align=center data-alt='/images/syntax/light/native.png'>
+<img src='/images/syntax/dark/native.png' width=750 align=center data-alt='/images/syntax/light/native.png' alt="screenshot of pgcli with the 'manni' color theme">
 </figure>
 
 # perldoc
 
 <figure>
 Click the image to toggle dark/light background.
-<img src='/images/syntax/dark/perldoc.png' width=750 align=center data-alt='/images/syntax/light/perldoc.png'>
+<img src='/images/syntax/dark/perldoc.png' width=750 align=center data-alt='/images/syntax/light/perldoc.png' alt="screenshot of pgcli with the 'perldoc' color theme">
 </figure>
 
 # borland
 
 <figure>
 Click the image to toggle dark/light background.
-<img src='/images/syntax/dark/borland.png' width=750 align=center data-alt='/images/syntax/light/borland.png'>
+<img src='/images/syntax/dark/borland.png' width=750 align=center data-alt='/images/syntax/light/borland.png' alt="screenshot of pgcli with the 'borland' color theme">
 </figure>
 
 # tango
 
 <figure>
 Click the image to toggle dark/light background.
-<img src='/images/syntax/dark/tango.png' width=750 align=center data-alt='/images/syntax/light/tango.png'>
+<img src='/images/syntax/dark/tango.png' width=750 align=center data-alt='/images/syntax/light/tango.png' alt="screenshot of pgcli with the 'tango' color theme">
 </figure>
 
 # emacs
 
 <figure>
 Click the image to toggle dark/light background.
-<img src='/images/syntax/dark/emacs.png' width=750 align=center data-alt='/images/syntax/light/emacs.png'>
+<img src='/images/syntax/dark/emacs.png' width=750 align=center data-alt='/images/syntax/light/emacs.png' alt="screenshot of pgcli with the 'emacs' color theme">
 </figure>
 
 # friendly
 
 <figure>
 Click the image to toggle dark/light background.
-<img src='/images/syntax/dark/friendly.png' width=750 align=center data-alt='/images/syntax/light/friendly.png'>
+<img src='/images/syntax/dark/friendly.png' width=750 align=center data-alt='/images/syntax/light/friendly.png' alt="screenshot of pgcli with the 'friendly' color theme">
 </figure>
 
 # monokai
 
 <figure>
 Click the image to toggle dark/light background.
-<img src='/images/syntax/dark/monokai.png' width=750 align=center data-alt='/images/syntax/light/monokai.png'>
+<img src='/images/syntax/dark/monokai.png' width=750 align=center data-alt='/images/syntax/light/monokai.png' alt="screenshot of pgcli with the 'monokai' color theme">
 </figure>
 
 # paraiso-dark
 
 <figure>
 Click the image to toggle dark/light background.
-<img src='/images/syntax/dark/paraiso-dark.png' width=750 align=center data-alt='/images/syntax/light/paraiso-dark.png'>
+<img src='/images/syntax/dark/paraiso-dark.png' width=750 align=center data-alt='/images/syntax/light/paraiso-dark.png' alt="screenshot of pgcli with the 'paraiso-dark' color theme">
 </figure>
 
 # paraiso-light
 
 <figure>
 Click the image to toggle dark/light background.
-<img src='/images/syntax/dark/paraiso-light.png' width=750 align=center data-alt='/images/syntax/light/paraiso-light.png'>
+<img src='/images/syntax/dark/paraiso-light.png' width=750 align=center data-alt='/images/syntax/light/paraiso-light.png' alt="screenshot of pgcli with the 'paraiso-light' color theme">
 </figure>
 
 # colorful
 
 <figure>
 Click the image to toggle dark/light background.
-<img src='/images/syntax/dark/colorful.png' width=750 align=center data-alt='/images/syntax/light/colorful.png'>
+<img src='/images/syntax/dark/colorful.png' width=750 align=center data-alt='/images/syntax/light/colorful.png' alt="screenshot of pgcli with the 'colorful' color theme">
 </figure>
 
 # murphy
 
 <figure>
 Click the image to toggle dark/light background.
-<img src='/images/syntax/dark/murphy.png' width=750 align=center data-alt='/images/syntax/light/murphy.png'>
+<img src='/images/syntax/dark/murphy.png' width=750 align=center data-alt='/images/syntax/light/murphy.png' alt="screenshot of pgcli with the 'murphy' color theme">
 </figure>
 
 # bw
 
 <figure>
 Click the image to toggle dark/light background.
-<img src='/images/syntax/dark/bw.png' width=750 align=center data-alt='/images/syntax/light/bw.png'>
+<img src='/images/syntax/dark/bw.png' width=750 align=center data-alt='/images/syntax/light/bw.png' alt="screenshot of pgcli with the 'bw' color theme">
 </figure>
 
 # pastie
 
 <figure>
 Click the image to toggle dark/light background.
-<img src='/images/syntax/dark/pastie.png' width=750 align=center data-alt='/images/syntax/light/pastie.png'>
+<img src='/images/syntax/dark/pastie.png' width=750 align=center data-alt='/images/syntax/light/pastie.png' alt="screenshot of pgcli with the 'pastie' color theme">
 </figure>
 
 # trac
 
 <figure>
 Click the image to toggle dark/light background.
-<img src='/images/syntax/dark/trac.png' width=750 align=center data-alt='/images/syntax/light/trac.png'>
+<img src='/images/syntax/dark/trac.png' width=750 align=center data-alt='/images/syntax/light/trac.png' alt="screenshot of pgcli with the 'trac' color theme">
 </figure>
 
 # fruity
 
 <figure>
 Click the image to toggle dark/light background.
-<img src='/images/syntax/dark/fruity.png' width=750 align=center data-alt='/images/syntax/light/fruity.png'>
+<img src='/images/syntax/dark/fruity.png' width=750 align=center data-alt='/images/syntax/light/fruity.png' alt="screenshot of pgcli with the 'fruity' color theme">
 </figure>


### PR DESCRIPTION
It makes images (a bit) more accessible.

---

Screenshot of the "Completion" page:

![alternate-text](https://github.com/user-attachments/assets/00437f11-0c83-46a1-b241-816e221c41f6)
